### PR TITLE
Fix type error on downloading image from my UV5R

### DIFF
--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -587,7 +587,7 @@ def _do_download(radio):
         data += _read_block(radio, i, 0x40, False)
 
     if append_model:
-        data += radio.MODEL.ljust(8)
+        data += bytes(radio.MODEL.ljust(8), 'utf-8')
 
     LOG.debug("done.")
     return memmap.MemoryMapBytes(data)


### PR DESCRIPTION
Pretty straightforward, trying to download throws a type error appending str to bytes, and this is the fix I used.