### PR TITLE
Fix Wouxun uv8 variants

### DIFF
--- a/chirp/drivers/kguv8d.py
+++ b/chirp/drivers/kguv8d.py
@@ -401,7 +401,7 @@ class KGUV8DRadio(chirp_common.CloneModeRadio,
         # allocate & fill memory
         image = ""
         for i in range(start, end, blocksize):
-            req = chr(i / 256) + chr(i % 256) + chr(blocksize)
+            req = chr(i // 256) + chr(i % 256) + chr(blocksize)
             self._write_record(CMD_RD, req)
             cs_error, resp = self._read_record()
             if cs_error:
@@ -433,7 +433,7 @@ class KGUV8DRadio(chirp_common.CloneModeRadio,
     def _do_upload(self, start, end, blocksize):
         ptr = start
         for i in range(start, end, blocksize):
-            req = chr(i / 256) + chr(i % 256)
+            req = chr(i // 256) + chr(i % 256)
             chunk = self.get_mmap()[ptr:ptr + blocksize]
             self._write_record(CMD_WR, req + chunk)
             LOG.debug(util.hexprint(req + chunk))

--- a/chirp/drivers/kguv8dplus.py
+++ b/chirp/drivers/kguv8dplus.py
@@ -443,7 +443,7 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
         # allocate & fill memory
         image = ""
         for i in range(start, end, blocksize):
-            req = chr(i / 256) + chr(i % 256) + chr(blocksize)
+            req = chr(i // 256) + chr(i % 256) + chr(blocksize)
             self._write_record(CMD_RD, req)
             cs_error, resp = self._read_record()
             if cs_error:
@@ -474,7 +474,7 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
     def _do_upload(self, start, end, blocksize):
         ptr = start
         for i in range(start, end, blocksize):
-            req = chr(i / 256) + chr(i % 256)
+            req = chr(i // 256) + chr(i % 256)
             chunk = self.get_mmap()[ptr:ptr + blocksize]
             self._write_record(CMD_WR, req + chunk)
             LOG.debug(util.hexprint(req + chunk))

--- a/chirp/drivers/kguv8e.py
+++ b/chirp/drivers/kguv8e.py
@@ -448,7 +448,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
         # allocate & fill memory
         image = ""
         for i in range(start, end, blocksize):
-            req = chr(i / 256) + chr(i % 256) + chr(blocksize)
+            req = chr(i // 256) + chr(i % 256) + chr(blocksize)
             self._write_record(CMD_RD, req)
             cs_error, resp = self._read_record()
             if cs_error:
@@ -479,7 +479,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
     def _do_upload(self, start, end, blocksize):
         ptr = start
         for i in range(start, end, blocksize):
-            req = chr(i / 256) + chr(i % 256)
+            req = chr(i // 256) + chr(i % 256)
             chunk = self.get_mmap()[ptr:ptr + blocksize]
             self._write_record(CMD_WR, req + chunk)
             # ~ LOG.debug(util.hexprint(req + chunk))

--- a/chirp/ui/common.py
+++ b/chirp/ui/common.py
@@ -406,10 +406,10 @@ def show_diff_blob(title, result):
 
     tags = b.get_tag_table()
     for color in ["red", "blue", "green", "grey"]:
-        tag = gtk.TextTag(color)
+        tag = gtk.TextTag()
         tag.set_property("foreground", color)
         tags.add(tag)
-    tag = gtk.TextTag("bold")
+    tag = gtk.TextTag()
     tag.set_property("weight", pango.WEIGHT_BOLD)
     tags.add(tag)
 
@@ -430,7 +430,8 @@ def show_diff_blob(title, result):
         else:
             tags = ()
         b.insert_with_tags_by_name(b.get_end_iter(), line + os.linesep, *tags)
-    v = gtk.TextView(b)
+    v = gtk.TextView()
+    v.set_buffer(b)
     fontdesc = pango.FontDescription("Courier %i" % fontsize)
     v.modify_font(fontdesc)
     v.set_editable(False)


### PR DESCRIPTION
Incorrect floating point division caused:

`chirp.errors.RadioError: Failed to communicate with radio: integer argument expected, got float`