### PR TITLE
Change use of deprecated collections.Callable class

### DIFF
--- a/chirp/pyPEG.py
+++ b/chirp/pyPEG.py
@@ -169,7 +169,7 @@ class parser(object):
             except:
                 pass
 
-        if isinstance(pattern, collections.Callable):
+        if isinstance(pattern, collections.abc.Callable):
             if __debug__:
                 if print_trace:
                     try:
@@ -184,7 +184,7 @@ class parser(object):
                 name = Name(pattern.__name__)
 
             pattern = pattern()
-            if isinstance(pattern, collections.Callable):
+            if isinstance(pattern, collections.abc.Callable):
                 pattern = (pattern,)
 
         text = skip(self.skipper, textline, skipWS, skipComments)
@@ -353,7 +353,7 @@ def parse(language, lineSource, skipWS=True, skipComments=None,
           packrat=False, lineCount=True):
     lines, lineNo = [], 0
 
-    while isinstance(language, collections.Callable):
+    while isinstance(language, collections.abc.Callable):
         language = language()
 
     orig, ld = "", 0


### PR DESCRIPTION
In Python 3.9, `collections.Callable` was marked deprecated. In Python 3.10, it does not exist.

Instead, it's been moved to `collections.abc.Callable`. So all uses of `collections.Callable` have been replaced with `collections.abc.Callable`.

This makes py3-CHIRP work on Python 3.10 as well.