### PR TITLE
chirp/drivers/kenwood_live.py add language encoding for latin

### DIFF
--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -84,7 +84,7 @@ def command(ser, cmd, *args):
 
     result = ""
     while not result.endswith(LAST_DELIMITER[0]):
-        result += ser.read(COMMAND_RESP_BUFSIZE).decode()
+        result += ser.read(COMMAND_RESP_BUFSIZE).decode('latin-')
         if (time.time() - start) > 0.5:
             LOG.error("Timeout waiting for data")
             break


### PR DESCRIPTION
I needed this for a Kenwood 2000X programming it on Gentoo