### PR TITLE
Minor fixes

### DIFF
--- a/chirp/drivers/ft60.py
+++ b/chirp/drivers/ft60.py
@@ -27,7 +27,7 @@ from textwrap import dedent
 
 LOG = logging.getLogger(__name__)
 
-ACK = "\x06"
+ACK = bytes(b"\x06")
 
 
 def _send(pipe, data):
@@ -38,7 +38,7 @@ def _send(pipe, data):
 
 
 def _download(radio):
-    data = ""
+    data = bytes(b"")
     for i in range(0, 10):
         chunk = radio.pipe.read(8)
         if len(chunk) == 8:

--- a/chirp/drivers/ft60.py
+++ b/chirp/drivers/ft60.py
@@ -577,7 +577,7 @@ class FT60Radio(yaesu_clone.YaesuCloneModeRadio):
 
         # LOCK
         opts = ["LK KEY", "LKDIAL", "LK K+D", "LK PTT",
-                "LP P+K", "LK P+D", "LK ALL"]
+                "LK P+K", "LK P+D", "LK ALL"]
         rs = RadioSetting("lock", "Control Locking",
                           RadioSettingValueList(
                               opts, opts[_settings.lock - 1]))

--- a/chirp/ui/importdialog.py
+++ b/chirp/ui/importdialog.py
@@ -51,13 +51,13 @@ class WaitWindow(gtk.Window):
 
     def grind(self):
         while gtk.events_pending():
-            gtk.main_iteration(False)
+            gtk.main_iteration()
 
         self.prog.pulse()
 
     def set(self, fraction):
         while gtk.events_pending():
-            gtk.main_iteration(False)
+            gtk.main_iteration()
 
         self.prog.set_fraction(fraction)
 

--- a/chirp/ui/importdialog.py
+++ b/chirp/ui/importdialog.py
@@ -20,6 +20,7 @@ import logging
 
 from chirp import errors, chirp_common, import_logic
 from chirp.ui import common
+from chirp.ui import compat
 
 LOG = logging.getLogger(__name__)
 
@@ -299,7 +300,7 @@ class ImportDialog(gtk.Dialog):
         self.__view = gtk.TreeView(self.__store)
         self.__view.show()
 
-        tips = gtk.Tooltips()
+        tips = compat.CompatTooltips()
 
         for k in list(self.caps.keys()):
             t = self.types[k]

--- a/chirp/ui/importdialog.py
+++ b/chirp/ui/importdialog.py
@@ -409,7 +409,7 @@ class ImportDialog(gtk.Dialog):
         inv.show()
         hbox.pack_start(inv, 0, 0, 0)
 
-        frame = gtk.Frame(_("Select"))
+        frame = compat.Frame(_("Select"))
         frame.show()
         frame.add(hbox)
         hbox.show()
@@ -467,7 +467,7 @@ class ImportDialog(gtk.Dialog):
         revr.show()
         hbox.pack_start(revr, 0, 0, 0)
 
-        frame = gtk.Frame(_("Adjust New Location"))
+        frame = compat.Frame(_("Adjust New Location"))
         frame.show()
         frame.add(hbox)
         hbox.show()
@@ -483,7 +483,7 @@ class ImportDialog(gtk.Dialog):
 
         hbox.pack_start(confirm, 0, 0, 0)
 
-        frame = gtk.Frame(_("Options"))
+        frame = compat.Frame(_("Options"))
         frame.add(hbox)
         frame.show()
         hbox.show()

--- a/chirp/ui/mainapp.py
+++ b/chirp/ui/mainapp.py
@@ -1327,7 +1327,7 @@ of file.
         # to make sure we process events leading up to this
         Gtk.Gdk.window_process_all_updates()
         while Gtk.events_pending():
-            Gtk.main_iteration(False)
+            Gtk.main_iteration()
 
         if do_import:
             eset = self.get_current_editorset()


### PR DESCRIPTION
After I updated my Gentoo system and installed the deps shown below, I found that py3-chirp needed some compatibility fixes. There's also a simple typo fix in this PR. I tested these changes by reprogramming a Yaesu FT60.
```
dev-lang/python-3.9.11
dev-python/pyserial-3.5-r1
dev-python/pygobject-3.42.0
dev-python/wxpython-4.0.7-r1
dev-python/future-0.18.2-r1
dev-python/six-1.16.0
```